### PR TITLE
parent site fully working

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -14,6 +14,7 @@ import NoteForm from "./note/NoteForm"
 import NoteEditForm from "./note/NoteEditForm"
 import MilestoneList from "./milestone/MilestoneList"
 import ParentCenter from "./student/ParentCenter"
+import CatchParent from "./lesson/CatchParent";
 
 const ApplicationViews = props => {
   const setUser = props.setUser;
@@ -87,7 +88,14 @@ const ApplicationViews = props => {
         exact
         path="/lessons"
         render={props => {
-          return hasUser ? <LessonList {...props} /> : <Redirect to="/login" />;
+          const isTeacher = Number(sessionStorage.getItem("type"))
+          if (hasUser && isTeacher === 1) {
+            return <LessonList {...props} />
+          } else if (hasUser && isTeacher === 0) {
+            return <CatchParent/>
+          } else {
+            return <Redirect to="/login" />
+          }
         }}
       />
       <Route

--- a/src/components/lesson/CatchParent.js
+++ b/src/components/lesson/CatchParent.js
@@ -1,0 +1,24 @@
+import React, {useEffect} from "react";
+
+const CatchParent = () => {
+    const parentAlert = () =>  {
+        window.alert("This Area is for Teachers Only")
+    }
+    
+    useEffect(() => {
+        parentAlert();
+      }, []);
+
+  return (
+    <>
+    <h1 onClick={parentAlert}>Teacher's Lounge</h1>
+    <img
+        src="https://tamaractalk.com/wp-content/uploads/2019/08/after-lounge-480x270.jpg"
+        alt="Teach Lounge"
+        onClick={parentAlert}
+      ></img>
+      </>
+  );
+};
+
+export default CatchParent;

--- a/src/components/milestone/MilestoneCard.js
+++ b/src/components/milestone/MilestoneCard.js
@@ -5,12 +5,12 @@ const MilestoneCard = props => {
     return (
       <div className="milestoneCard">
         <div className="milestoneCardContent">
-          <input
+        {props.isTeacher ? <input
             type="checkbox"
             id="completeDate"
             checked={false}
             onChange={() => props.toggleCompleteMilestone(props.milestone.id, false)}
-          />
+          /> : null }
             <span className="milestoneCardTitle">{props.milestone.milestone}</span>
         </div>
       </div>
@@ -19,12 +19,12 @@ const MilestoneCard = props => {
     return (
         <div className="milestoneCard">
         <div className="milestoneCardContent">
-          <input
+        {props.isTeacher ? <input
             type="checkbox"
             id="completeDate"
             checked={true}
             onChange={() => props.toggleCompleteMilestone(props.milestone.id, true)}
-          />
+          /> : null }
             <strong><span className="milestoneCardTitle">{props.milestone.milestone} Completed: {props.milestone.completeDate}</span></strong>
         </div>
       </div>

--- a/src/components/milestone/MilestoneList.js
+++ b/src/components/milestone/MilestoneList.js
@@ -7,6 +7,8 @@ import moment from "moment";
 
 const MilestoneList = props => {
   const student = Number(sessionStorage.getItem("current"));
+  const isTeacher = Number(sessionStorage.getItem("type"));
+
   const [milestones, setMilestones] = useState([]);
   const [completed, setCompleted] = useState([]);
   const [notCompleted, setNotCompleted] = useState([]);
@@ -81,9 +83,9 @@ const MilestoneList = props => {
         ))}
       </div>
       <section className="manageViewToggle">
-        <button type="button" className="btn" onClick={toggleManageView}>
+      {isTeacher ?<button type="button" className="btn" onClick={toggleManageView}>
           Manage Milestones
-        </button>
+        </button> : null}
       </section>
     </>
   ) : (
@@ -97,6 +99,7 @@ const MilestoneList = props => {
           <MilestoneManageCard
             key={milestone.id}
             milestone={milestone}
+            isTeacher={isTeacher}
             getMilestones={getMilestones}
             deleteMilestone={deleteMilestone}
             {...props}

--- a/src/components/note/NoteCard.js
+++ b/src/components/note/NoteCard.js
@@ -20,6 +20,7 @@ const NoteCard = props => {
         <p>
           {props.note.note}
         </p>
+        {props.isTeacher ? <section className = "buttons">
         <button
           type="button"
           onClick={() => props.history.push(`/notes/${props.note.id}/edit`)}
@@ -31,7 +32,8 @@ const NoteCard = props => {
           onClick={() => props.deleteNote(props.note.id)}
         >
           Delete Note
-        </button>
+        </button> 
+        </section>: null}
       </div>
     </div>
   );

--- a/src/components/note/NoteList.js
+++ b/src/components/note/NoteList.js
@@ -5,13 +5,19 @@ import NoteManager from "../../modules/NoteManager";
 const NoteList = props => {
   const [notes, setNotes] = useState([]);
   const student = Number(sessionStorage.getItem("current"));
+  const isTeacher = Number(sessionStorage.getItem("type"));
 
   const getNotes = () => {
     if (student) {
-      return NoteManager.getAll().then(allNotes => {
+      return isTeacher ? (NoteManager.getAll().then(allNotes => {
         const myNotes = allNotes.filter(note => student === note.studentId);
-        setNotes(myNotes);
-      });
+        setNotes(myNotes)
+      })) : (
+        NoteManager.getAll().then(allNotes => {
+          const myNotes = allNotes.filter(note => student === note.studentId && !note.isPrivate);
+          setNotes(myNotes)
+        })
+      )
     }
   };
 
@@ -33,7 +39,7 @@ const NoteList = props => {
   ) : (
     <>
       <section className="section-content">
-        <button
+      {isTeacher ? <button
           type="button"
           className="btn"
           onClick={() => {
@@ -41,13 +47,14 @@ const NoteList = props => {
           }}
         >
           Write New Note
-        </button>
+        </button>  : null}
       </section>
       <div className="container-cards">
         {notes.map(note => (
           <NoteCard
             key={note.id}
             note={note}
+            isTeacher={isTeacher}
             deleteNote={deleteNote}
             {...props}
           />


### PR DESCRIPTION
Now parents have a different site view than teachers
Parents still required to select student for view of other tabs.
to add a child to their viewable list,  parents must know the name of their own child
This is for mild security so that parents can not view other children's data
once child is selected lessons tab is barred from parents still as it is a teacher only area
notes will display notes that the teacher has authorized parents to see
lastly milestones displays a list of the childs milestones with all other crud functions stripped away.